### PR TITLE
Add support for YAML files when reading configuration files.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,11 @@
     </profiles>
 
     <dependencies>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.21</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Read yaml using SnakeYAML (https://bitbucket.org/asomov/snakeyaml).
And then put the Map object output to Properties object.
Class Environment no longer extends Properties but has Properties object in its instance variable.